### PR TITLE
Rust PR 75180 fix.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -582,15 +582,6 @@ impl<T: 'static + Display + Debug> Error for ChainError<T> {
     }
 }
 
-impl<T: 'static + Display + Debug> Error for &ChainError<T> {
-    #[inline]
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        self.error_cause
-            .as_ref()
-            .map(|e| e.as_ref() as &(dyn Error + 'static))
-    }
-}
-
 impl<T: 'static + Display + Debug> Error for &mut ChainError<T> {
     #[inline]
     fn source(&self) -> Option<&(dyn Error + 'static)> {


### PR DESCRIPTION
Removes now unnecessary implementation of Error trait. Will be merge'able once Rust hits 1.51 [PR](https://github.com/rust-lang/rust/pull/75180)