### PR TITLE
doc: add usage example for error handling in main function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -689,6 +689,12 @@ macro_rules! str_context {
 ///     do_some_io(filename).map_context(|e| ErrorKind::from(e))?;
 ///     Ok(())
 /// }
+///
+/// # fn main() {
+/// #   if let Err(e) = func1() {
+/// #       eprintln!("Error:\n{:?}", e);
+/// #   }
+/// # }
 /// ```
 #[macro_export]
 macro_rules! err_kind {


### PR DESCRIPTION
This commit adds a usage example demonstrating how to handle errors returned by the `func1` function in the main function. The example provides clarity on practical error handling and makes the documentation more comprehensive for users.